### PR TITLE
Dselans/handle nil acknowledger

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/sirupsen/logrus"
+
+	"github.com/streamdal/rabbit"
+)
+
+func main() {
+	llog := logrus.New()
+	llog.SetLevel(logrus.DebugLevel)
+
+	// Create rabbit instance
+	r, err := setup(llog)
+	if err != nil {
+		llog.Fatalf("Unable to setup rabbit: %s", err)
+	}
+
+	errChan := make(chan *rabbit.ConsumeError, 1)
+
+	llog.Debug("Starting error listener...")
+
+	// Launch an error listener
+	go func() {
+		for {
+			select {
+			case err := <-errChan:
+				llog.Debugf("Received rabbit error: %v", err)
+			}
+		}
+	}()
+
+	llog.Debug("Running consumer...")
+
+	// Run a consumer
+	r.Consume(context.Background(), errChan, func(d amqp.Delivery) error {
+		llog.Debugf("[Received message]\nHeaders: %v\nBody: %s\n", d.Headers, d.Body)
+
+		// Acknowledge the message
+		if err := d.Ack(false); err != nil {
+			llog.Errorf("Error acknowledging message: %s", err)
+		}
+
+		return nil
+	})
+}
+
+func setup(logger *logrus.Logger) (*rabbit.Rabbit, error) {
+	return rabbit.New(&rabbit.Options{
+		URLs:      []string{"amqp://guest:guest@localhost:5672/"},
+		Mode:      rabbit.Both,
+		QueueName: "test-queue",
+		Bindings: []rabbit.Binding{
+			{
+				ExchangeName:       "test-exchange",
+				BindingKeys:        []string{"test-key"},
+				ExchangeDeclare:    true,
+				ExchangeType:       "topic",
+				ExchangeDurable:    true,
+				ExchangeAutoDelete: true,
+			},
+		},
+		RetryReconnectSec: 1,
+		QueueDurable:      true,
+		QueueExclusive:    false,
+		QueueAutoDelete:   true,
+		QueueDeclare:      true,
+		AutoAck:           false,
+		ConsumerTag:       "rabbit-example",
+		Log:               logger,
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/rabbitmq/amqp091-go v1.10.0
 	github.com/relistan/go-director v0.0.0-20240410125439-78829fce487d
 	github.com/satori/go.uuid v1.2.0
+	github.com/sirupsen/logrus v1.9.3 // indirect
 	google.golang.org/protobuf v1.24.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -61,12 +61,15 @@ github.com/relistan/go-director v0.0.0-20240410125439-78829fce487d h1:nNavMkv4sC
 github.com/relistan/go-director v0.0.0-20240410125439-78829fce487d/go.mod h1:zxI04y3OTmbrx/ef0ahmkEy9/eBLLseHAjy6M5iKsws=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -97,6 +100,8 @@ golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299 h1:DYfZAGf2WMFjMxbgTjaC+2HC7NkNAQs+6Q8b9WEB/F4=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/rabbit.go
+++ b/rabbit.go
@@ -36,6 +36,8 @@ const (
 	Consumer Mode = 1
 	// Producer means that the client is acting as a producer.
 	Producer Mode = 2
+
+	ForceReconnectHeader = "rabbit-force-reconnect"
 )
 
 var (
@@ -67,6 +69,9 @@ type Rabbit struct {
 	ConsumerDeliveryChannel <-chan amqp.Delivery
 	ConsumerRWMutex         *sync.RWMutex
 	NotifyCloseChan         chan *amqp.Error
+	ReconnectChan           chan struct{}
+	ReconnectInProgress     bool
+	ReconnectInProgressMtx  *sync.RWMutex
 	ProducerServerChannel   *amqp.Channel
 	ProducerRWMutex         *sync.RWMutex
 	ConsumeLooper           director.Looper
@@ -209,12 +214,15 @@ func New(opts *Options) (*Rabbit, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	r := &Rabbit{
-		Conn:            ac,
-		ConsumerRWMutex: &sync.RWMutex{},
-		NotifyCloseChan: make(chan *amqp.Error),
-		ProducerRWMutex: &sync.RWMutex{},
-		ConsumeLooper:   director.NewFreeLooper(director.FOREVER, make(chan error, 1)),
-		Options:         opts,
+		Conn:                   ac,
+		ConsumerRWMutex:        &sync.RWMutex{},
+		NotifyCloseChan:        make(chan *amqp.Error),
+		ReconnectChan:          make(chan struct{}, 1),
+		ReconnectInProgress:    false,
+		ReconnectInProgressMtx: &sync.RWMutex{},
+		ProducerRWMutex:        &sync.RWMutex{},
+		ConsumeLooper:          director.NewFreeLooper(director.FOREVER, make(chan error, 1)),
+		Options:                opts,
 
 		ctx:    ctx,
 		cancel: cancel,
@@ -230,7 +238,7 @@ func New(opts *Options) (*Rabbit, error) {
 	ac.NotifyClose(r.NotifyCloseChan)
 
 	// Launch connection watcher/reconnect
-	go r.watchNotifyClose()
+	go r.runWatcher()
 
 	return r, nil
 }
@@ -385,18 +393,24 @@ func (r *Rabbit) Consume(ctx context.Context, errChan chan *ConsumeError, f func
 
 		select {
 		case msg := <-r.delivery():
-			if err := f(msg); err != nil {
-				r.log.Debugf("error during consume: %s", err)
+			if _, ok := msg.Headers[ForceReconnectHeader]; ok || msg.Acknowledger == nil {
+				r.writeError(errChan, &ConsumeError{
+					Message: &msg,
+					Error:   errors.New("nil acknowledger detected - sending reconnect signal"),
+				})
 
-				if errChan != nil {
-					// Write in a goroutine in case error channel is not consumed fast enough
-					go func() {
-						errChan <- &ConsumeError{
-							Message: &msg,
-							Error:   err,
-						}
-					}()
-				}
+				r.ReconnectChan <- struct{}{}
+
+				// No point in continuing execution of consumer func as the
+				// delivery msg is incomplete/invalid.
+				return nil
+			}
+
+			if err := f(msg); err != nil {
+				r.writeError(errChan, &ConsumeError{
+					Message: &msg,
+					Error:   fmt.Errorf("error during consume: %s", err),
+				})
 			}
 		case <-ctx.Done():
 			r.log.Warn("stopped via context")
@@ -411,6 +425,30 @@ func (r *Rabbit) Consume(ctx context.Context, errChan chan *ConsumeError, f func
 		return nil
 	})
 	r.log.Debug("Consume finished - exiting")
+}
+
+func (r *Rabbit) writeError(errChan chan *ConsumeError, err *ConsumeError) {
+	if err == nil {
+		r.log.Error("nil 'err' passed to writeError - bug?")
+		return
+	}
+
+	r.log.Warnf("writeError(): %s", err.Error)
+
+	if errChan == nil {
+		// Don't have an error channel, nothing else to do
+		return
+	}
+
+	// Only write to errChan if it's not full (to avoid goroutine leak)
+	if len(errChan) > 0 {
+		r.log.Warn("errChan is full - dropping message")
+		return
+	}
+
+	go func() {
+		errChan <- err
+	}()
 }
 
 // ConsumeOnce will consume exactly one message from the configured queue,
@@ -435,6 +473,14 @@ func (r *Rabbit) ConsumeOnce(ctx context.Context, runFunc func(msg amqp.Delivery
 
 	select {
 	case msg := <-r.delivery():
+		if msg.Acknowledger == nil {
+			r.log.Warn("Detected nil acknowledger - sending signal to rabbit lib to reconnect")
+
+			r.ReconnectChan <- struct{}{}
+
+			return errors.New("detected nil acknowledger - sent signal to reconnect to RabbitMQ")
+		}
+
 		if err := runFunc(msg); err != nil {
 			return err
 		}
@@ -535,12 +581,30 @@ func (r *Rabbit) Close() error {
 	return nil
 }
 
-func (r *Rabbit) watchNotifyClose() {
-	// TODO: Use a looper here
-	for {
-		closeErr := <-r.NotifyCloseChan
+func (r *Rabbit) getReconnectInProgress() bool {
+	r.ReconnectInProgressMtx.RLock()
+	defer r.ReconnectInProgressMtx.RUnlock()
 
-		r.log.Debugf("received message on notify close channel: '%+v' (reconnecting)", closeErr)
+	return r.ReconnectInProgress
+}
+
+func (r *Rabbit) runWatcher() {
+	for {
+		select {
+		case closeErr := <-r.NotifyCloseChan:
+			r.log.Debugf("received message on notify close channel: '%+v' (reconnecting)", closeErr)
+		case <-r.ReconnectChan:
+			if r.getReconnectInProgress() {
+				// Already reconnecting, nothing to do
+				r.log.Debug("received reconnect signal (already reconnecting)")
+				return
+			}
+
+			r.ReconnectInProgressMtx.Lock()
+			r.ReconnectInProgress = true
+
+			r.log.Debug("received reconnect signal (reconnecting)")
+		}
 
 		// Acquire mutex to pause all consumers/producers while we reconnect AND prevent
 		// access to the channel map
@@ -556,11 +620,13 @@ func (r *Rabbit) watchNotifyClose() {
 				time.Sleep(time.Duration(r.Options.RetryReconnectSec) * time.Second)
 				continue
 			}
+
 			r.log.Debugf("successfully reconnected after %d attempts", attempts)
+
 			break
 		}
 
-		// Create and set a new notify close channel (since old one gets shutdown)
+		// Create and set a new notify close channel (since old one may have gotten shutdown)
 		r.NotifyCloseChan = make(chan *amqp.Error, 0)
 		r.Conn.NotifyClose(r.NotifyCloseChan)
 
@@ -585,7 +651,14 @@ func (r *Rabbit) watchNotifyClose() {
 		// Unlock so that consumers/producers can begin reading messages from a new channel
 		r.ConsumerRWMutex.Unlock()
 		r.ProducerRWMutex.Unlock()
-		r.log.Debug("watchNotifyClose has completed successfully")
+
+		// If this was a requested reconnect - reset in progress flag
+		if r.ReconnectInProgress {
+			r.ReconnectInProgress = false
+			r.ReconnectInProgressMtx.Unlock()
+		}
+
+		r.log.Debug("runWatcher iteration has completed successfully")
 	}
 }
 

--- a/rabbit_test.go
+++ b/rabbit_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/relistan/go-director"
 	uuid "github.com/satori/go.uuid"
-
 	// to test with logrus, uncomment the following
 	// and the log initialiser in generateOptions()
 	// "github.com/sirupsen/logrus"
@@ -776,13 +775,13 @@ var _ = Describe("Rabbit", func() {
 	Describe("Reconnect testing", func() {
 		When("runWatcher receives reconnect signal", func() {
 			It("performs a reconnect", func() {
-
+				// TODO: Implement
 			})
 		})
 
 		When("runWatcher receives a notify close signal", func() {
 			It("performs a reconnect", func() {
-
+				// TODO: Implement
 			})
 		})
 


### PR DESCRIPTION
Rabbit library will now attempt to reconnect if it comes upon a `msg` with a `nil` `Acknowledger` on `amqp.Delivery`.

I am not sure how to reproduce this as it seems to occur when RabbitMQ is under duress and RabbitMQ's supervisor kills a child that is used for the connection.

Since reproducing this test case is complicated, I added a `rabbit-force-reconnect` header check in the reconnect logic. If this header is present, `rabbit` lib will reconnect.

Also, updated `Publish()` to accept optional headers.