### PR TITLE
Dselans/graceful-exit

### DIFF
--- a/rabbit_test.go
+++ b/rabbit_test.go
@@ -798,6 +798,7 @@ var _ = Describe("Rabbit", func() {
 				r := &Rabbit{
 					Conn:                    ac,
 					ConsumerRWMutex:         &sync.RWMutex{},
+					ConsumerWG:              &sync.WaitGroup{},
 					NotifyCloseChan:         notifyCloseCh,
 					ReconnectChan:           reconnectCh,
 					ConsumerDeliveryChannel: deliveryCh,

--- a/rabbit_test.go
+++ b/rabbit_test.go
@@ -12,7 +12,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
-	"github.com/relistan/go-director"
 	uuid "github.com/satori/go.uuid"
 	// to test with logrus, uncomment the following
 	// and the log initialiser in generateOptions()
@@ -102,7 +101,6 @@ var _ = Describe("Rabbit", func() {
 				Expect(r.ConsumerRWMutex).ToNot(BeNil())
 				Expect(r.NotifyCloseChan).ToNot(BeNil())
 				Expect(r.ProducerRWMutex).ToNot(BeNil())
-				Expect(r.ConsumeLooper).ToNot(BeNil())
 				Expect(r.Options).ToNot(BeNil())
 			})
 
@@ -805,7 +803,6 @@ var _ = Describe("Rabbit", func() {
 					ConsumerDeliveryChannel: deliveryCh,
 					ReconnectInProgressMtx:  &sync.RWMutex{},
 					ProducerRWMutex:         &sync.RWMutex{},
-					ConsumeLooper:           director.NewFreeLooper(director.FOREVER, make(chan error, 1)),
 					Options:                 opts,
 
 					log:    &NoOpLogger{},


### PR DESCRIPTION
1. Remove looper to avoid races where Consume is ran in multiple goroutines. Full fix (without removing looper) would mean to create a map of loopers per Consume() but that's a decent chunk of work.
2. Update Stop() to wait for Consume()'s to exit (using a waitgroup) + optional timeout